### PR TITLE
MobileTwitterのサポート

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -24,7 +24,7 @@
     "default_popup": "pages/popup.html"
   },
   "content_scripts": [{
-    "matches": ["https://twitter.com/*"],
+    "matches": ["https://twitter.com/*","https://mobile.twitter.com/*"],
     "js": ["scripts/contentscript.js"],
     "css": ["styles/contentscript.css"],
     "run_at": "document_end"


### PR DESCRIPTION
## 変更内容

https://mobile.twitter.com/ でも有効となる対応をいれました。

## 動作確認

下記の環境にて、dist配下の拡張を実際に動かして、対応状況を確認しています。

Mac: Catalina 10.15.7
Chrome: 86.0.4240.75 