### PR TITLE
プロモーションツイートを非表示にする機能を追加

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -42,6 +42,9 @@
   "titleIsWhoToFollowHidden": {
     "message": "Hide Who to follow"
   },
+  "titleIsPromotionTweetHidden": {
+    "message": "Hide Promotion tweet"
+  },
   "titleIsFontChanged": {
     "message": "Change Japanese font from Meiryo to Hiragino on Mac"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -38,6 +38,9 @@
   "titleIsWhoToFollowHidden": {
     "message": "おすすめユーザーを隠す"
   },
+  "titleIsPromotionTweetHidden": {
+    "message": "プロモーションツイートを隠す"
+  },
   "titleIsFontChanged": {
     "message": "Macで日本語フォントをメイリオからヒラギノに変更"
   },

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -45,6 +45,10 @@
       <span>__MSG_titleIsTopicsToFollowHidden__</span>
     </label>
     <label class="check">
+      <input type="checkbox" id="isPromotionTweetHidden">
+      <span>__MSG_titleIsPromotionTweetHidden__</span>
+    </label>
+    <label class="check">
       <input type="checkbox" id="isFontChanged">
       <span>__MSG_titleIsFontChanged__</span>
     </label>

--- a/app/scripts/contentscript.ts
+++ b/app/scripts/contentscript.ts
@@ -1,4 +1,4 @@
-toggleClass(["isExploreHidden", "isTrendsHidden", "isReactionNumberHidden", "showCalmText", "isFollowingNumberHidden", "isFollowerNumberHidden", "isReactionNumberAlwaysHidden", "isWhoToFollowHidden", "isTopicsToFollowHidden", "isFontChanged"]);
+toggleClass(["isExploreHidden", "isTrendsHidden", "isReactionNumberHidden", "showCalmText", "isFollowingNumberHidden", "isFollowerNumberHidden", "isReactionNumberAlwaysHidden", "isWhoToFollowHidden", "isTopicsToFollowHidden", "isFontChanged", "isPromotionTweetHidden"]);
 addCalmTitle();
 for (let i = 0; i < 2; i++) {
 	setTimeout(changeCalmColor, (i + 1)*100);
@@ -7,7 +7,7 @@ for (let i = 0; i < 2; i++) {
 function toggleClass(keys: string[]) {
   chrome.storage.local.get(keys, function (data) {
     keys.forEach(key => {
-      if (key === "isFollowingNumberHidden" || key === "isFollowerNumberHidden" || key === "isReactionNumberAlwaysHidden" || key === "isWhoToFollowHidden" || key === "isTopicsToFollowHidden" || key === "isFontChanged") {
+      if (key === "isFollowingNumberHidden" || key === "isFollowerNumberHidden" || key === "isReactionNumberAlwaysHidden" || key === "isWhoToFollowHidden" || key === "isTopicsToFollowHidden" || key === "isFontChanged" || key === "isPromotionTweetHidden") {
         if (typeof data[key] === "undefined") {
           data[key] = false;
         }

--- a/app/scripts/popup.ts
+++ b/app/scripts/popup.ts
@@ -1,5 +1,5 @@
 localize();
-initValues(["isExploreHidden", "isTrendsHidden", "isReactionNumberHidden", "showCalmText", "isFollowingNumberHidden", "isFollowerNumberHidden", "isReactionNumberAlwaysHidden", "isWhoToFollowHidden", "isTopicsToFollowHidden", "isFontChanged"]);
+initValues(["isExploreHidden", "isTrendsHidden", "isReactionNumberHidden", "showCalmText", "isFollowingNumberHidden", "isFollowerNumberHidden", "isReactionNumberAlwaysHidden", "isWhoToFollowHidden", "isTopicsToFollowHidden", "isFontChanged", "isPromotionTweetHidden"]);
 
 function localize() {
   var objects = document.getElementsByTagName('html');
@@ -37,7 +37,7 @@ function toggleChecked(keys: string[]) {
   chrome.storage.local.get(keys, function (data) {
     keys.forEach(key => {
       console.log(key + ": " + data[key]);
-      if (key === "isFollowingNumberHidden" || key === "isFollowerNumberHidden" || key === "isReactionNumberAlwaysHidden" || key === "isWhoToFollowHidden" || key === "isTopicsToFollowHidden" || key === "isFontChanged") {
+      if (key === "isFollowingNumberHidden" || key === "isFollowerNumberHidden" || key === "isReactionNumberAlwaysHidden" || key === "isWhoToFollowHidden" || key === "isTopicsToFollowHidden" || key === "isFontChanged" || key === "isPromotionTweetHidden") {
         if (typeof data[key] === "undefined") {
           data[key] = false;
         }

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -139,6 +139,12 @@ body {
     }
   }
 
+  &.isPromotionTweetHidden {
+    div.css-1dbjc4n.r-1igl3o0.r-qklmqi.r-1adg3ll.r-1ny4l3l > div[data-testid] {
+      display: none !important;
+    }
+  }
+
   &.isFontChanged {
     .r-1tl8opc {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", Meiryo, system-ui, sans-serif;


### PR DESCRIPTION
## 概要

Twitter のタイムラインのプロモーションツイートを非表示にする機能を追加しました。
（よくタイムラインの上から2番目に表示されるアレです）

## 変更詳細

- ポップアップメニューに「プロモーションツイートを隠す」を追加
- 「プロモーションツイートを隠す」が有効な場合、プロモーションツイートを抽出する CSS セレクタに一致する要素を非表示にする style を追加

## キャプチャ



https://user-images.githubusercontent.com/30320735/147255707-55ff6811-8fb7-415e-b890-8fe0bd4f456a.mov



## 検証環境

以下の環境で動作確認済み。

- OS : macOS 12.0.1
- ブラウザ :Google Chrome 96.0.4664.110（Official Build）（x86_64）

## その他

過去の PR に倣ってマージ先は develop にしています。
