### PR TITLE
ツイートの表示回数を非表示に

### DIFF
--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -28,13 +28,13 @@ body {
   }
 
   &.isReactionNumberHidden {
-    div[data-testid="primaryColumn"] article:not(:hover) div[role="group"] div[role="button"] span {
+    div[data-testid="primaryColumn"] article:not(:hover) div[role="group"] span {
       opacity: 0 !important;
       transition-property: transform, opacity !important;
     }
 
     &.isReactionNumberAlwaysHidden {
-      div[data-testid="primaryColumn"] article div[role="group"] div[role="button"] span {
+      div[data-testid="primaryColumn"] article div[role="group"] span {
         opacity: 0 !important;
         transition-property: transform, opacity !important;
       }


### PR DESCRIPTION
日本時間 2022/12/23 の朝に追加された、「ツイートの表示回数」のラベルを非表示にするよう変更しました。

Before:
![hide_impression_before](https://user-images.githubusercontent.com/22492054/209256581-db78fdbc-dc44-4d75-a664-ae520cc4c84b.png)

After:
![hide_impression](https://user-images.githubusercontent.com/22492054/209256579-39df7a5d-696c-4bdd-988d-48d8bb8449a5.png)