### PR TITLE
動作対象ドメインに`https://x.com/*`を追加

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -24,6 +24,7 @@
   "content_scripts": [
     {
       "matches": [
+        "https://x.com/*",
         "https://twitter.com/*",
         "https://mobile.twitter.com/*"
       ],


### PR DESCRIPTION
Resolves #51

## 行なった動作確認
1. ローカルで`npm run start`を実行
2. `dist`ディレクトリの内容を拡張機能として読み込み
3. トレンド表示が消えていることを確認
  
<img width="1858" alt="image" src="https://github.com/yusukesaitoh/calm-twitter/assets/49891479/9f67aafc-e110-4994-b170-607b34169e3f">
