### PR TITLE
Add mobile.x.com/* to manifest.json

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -25,6 +25,7 @@
     {
       "matches": [
         "https://x.com/*",
+        "https://mobile.x.com/*",
         "https://twitter.com/*",
         "https://mobile.twitter.com/*"
       ],


### PR DESCRIPTION
関連リンクに挙げたissueとPull Requestを見ていて、`content_scripts.matches` に `https://mobile.x.com/` が追加されていないことに気づいたので含めるようにしました。

## 関連リンク

* https://github.com/yusukesaitoh/calm-twitter/issues/51
* https://github.com/yusukesaitoh/calm-twitter/pull/52