### PR TITLE
サイドバーからサブスクライブとニュースセクションを非表示にする機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,42 @@
 This extension hides trending information from twitter timelines to make your mind calm.  
 この拡張機能はTwitterのタイムラインからトレンド情報を隠して、あなたの心を穏やかにしてくれます。
 
+- Hide unnecessary items from navigation
+- Hide numbers of replies, retweets, likes, bookmarks, and view counts
+- Hide trends, who to follow, subscribe prompts, and news from sidebar
+- Hide following and follower counts
+- Show "Calm" next to the logo
+
 ![](images/about.png)
 
-1. Hide "Explore" tab from the left column
-2. Hide trends and who to follow from the right column
-3. Hide numbers of replies, retweets, and likes.  They appear when you hover the mouse cursor on the tweet
-4. Show "Calm" next to the Twitter logo
+## Main Features (on by default)
+- Hide trends, who to follow, subscribe prompts, and news from the right sidebar
+- Hide numbers of replies, retweets, and likes (they appear when you hover)
+- Hide view counts
+- Hide "Explore" tab from navigation
+- Show "Calm" next to the Twitter/X logo
 
-Additional features (off by default, can be turned on from settings)
+## Additional Features (can be toggled in settings)
 
-5. Hide the number of following
-6. Hide the number of followers
-7. Hide numbers of replies, retweets, and likes in detail pages
-8. Hide numbers of replies, retweets, and likes, even if you hover the mouse cursor on the tweet
-9. Hide Who to follow
-10. Hide Topics to follow
-11. Change Japanese font from Meiryo to Hiragino on Mac
+### Navigation
+- Hide Grok
+- Hide Jobs
+- Hide Communities
+- Hide Premium
+- Hide Verified Organizations
+
+### User Numbers
+- Hide the number of following
+- Hide the number of followers
+
+### Tweet Interactions
+- Hide reaction numbers even when hovering
+- Hide reaction numbers in detail pages
+- Hide Who to follow sections
+- Hide Topics to follow sections
+
+### Display
+- Change Japanese font from Meiryo to Hiragino on Mac
 
 ## License
 MIT License

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -16,7 +16,7 @@
     "description": "The title of the browser action button"
   },
   "titleIsTrendsHidden": {
-    "message": "Hide trends and who to follow from right column"
+    "message": "Hide trends, who to follow, subscribe, and news from right column"
   },
   "titleIsReactionNumberHidden": {
     "message": "Hide numbers of reactions"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -12,7 +12,7 @@
     "description": "The title of the browser action button"
   },
   "titleIsTrendsHidden": {
-    "message": "おすすめトレンド、ユーザーを隠す"
+    "message": "おすすめトレンド、ユーザー、サブスクライブ、ニュースを隠す"
   },
   "titleIsReactionNumberHidden": {
     "message": "ツイートへのリアクション数を隠す"

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -45,7 +45,9 @@ body {
       div:has(> div > aside > a[href="/i/premium_sign_up"]),
       div:has(> div > aside > ul > li[data-testid="UserCell"]),
       div:has(> section div > div > div[data-testid="trend"]),
-      div:has(> div[data-testid="placementTracking"] > button div[data-testid="pill-contents-container"] div[data-testid="UserAvatar-Container-unknown"]) {
+      div:has(> div[data-testid="placementTracking"] > button div[data-testid="pill-contents-container"] div[data-testid="UserAvatar-Container-unknown"]),
+      div[data-testid="super-upsell-UpsellCardRenderProperties"],
+      div:has(> div[data-testid="news_sidebar"]) {
         display: none !important;
       }
     }


### PR DESCRIPTION
## 概要
Twitter/Xのサイドバーに表示される「プレミアムにサブスクライブ」と「本日のニュース」セクションを非表示にする機能を追加しました。既存の`isTrendsHidden`オプションに統合することで、サイドバーのノイズを一括で非表示にできます。

## 主な変更内容
- `contentscript.scss`: `isTrendsHidden`に2つの新しいセレクタを追加
  - `div[data-testid="super-upsell-UpsellCardRenderProperties"]`: プレミアムサブスクライブカード
  - `div:has(> div[data-testid="news_sidebar"])`: ニュースセクションの親要素
- 日本語と英語のメッセージファイルを更新して新機能を反映
- README.mdを最新の機能リストに更新

## 確認項目
- [x] Chrome拡張機能として正常にビルドできる
- [x] サブスクライブセクションが非表示になる
- [x] ニュースセクションが非表示になる
- [x] 他のUI要素に影響を与えない
- [x] 設定画面で機能の説明が正しく表示される

## 関連Issue
Closes #65