### PR TITLE
「おすすめ」タブを非表示にする

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -15,6 +15,9 @@
     "message": "Calm Twitter",
     "description": "The title of the browser action button"
   },
+  "titleIsForYouHidden": {
+    "message": "Hide \"For You\" timeline tab"
+  },
   "titleIsTrendsHidden": {
     "message": "Hide trends, who to follow, subscribe, and news from right column"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -11,6 +11,9 @@
     "message": "おだやかTwitter",
     "description": "The title of the browser action button"
   },
+  "titleIsForYouHidden": {
+    "message": "「おすすめ」タイムラインタブを隠す"
+  },
   "titleIsTrendsHidden": {
     "message": "おすすめトレンド、ユーザー、サブスクライブ、ニュースを隠す"
   },

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -20,6 +20,10 @@
     </div>
     <div class="feature-section open">
       <label class="check">
+        <input type="checkbox" id="isForYouHidden" checked>
+        <span>__MSG_titleIsForYouHidden__</span>
+      </label>
+      <label class="check">
         <input type="checkbox" id="isTrendsHidden" checked>
         <span>__MSG_titleIsTrendsHidden__</span>
       </label>

--- a/app/scripts/constants.ts
+++ b/app/scripts/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_SETTINGS = {
   isCommunitiesHidden: true,
   isPremiumHidden: true,
   isVerifiedOrganizationsHidden: true,
+  isForYouHidden: true,
 } as const;
 
 export const SECTION_STATES = {

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -40,6 +40,12 @@ body {
     }
   }
   
+  &.isForYouHidden {
+    div[data-testid="primaryColumn"] div[role="tablist"] > div:first-child {
+      display: none !important;
+    }
+  }
+
   &.isTrendsHidden {
     div[data-testid="sidebarColumn"] {
       div:has(> div > aside > a[href="/i/premium_sign_up"]),


### PR DESCRIPTION
close https://github.com/yusukesaitoh/calm-twitter/issues/70

どうしてもこれを非表示にしたく実装しました
とてもおだやかになりました

<img width="600" alt="CleanShot 2026-03-12 at 19 24 12@2x" src="https://github.com/user-attachments/assets/e7370552-f2e6-4e43-9f35-03be0030c1fc" />

---

<img width="600" alt="CleanShot 2026-03-12 at 19 24 20@2x" src="https://github.com/user-attachments/assets/d6d08d8d-9c4b-44f5-aca1-97095d32cb14" />


