### PR TITLE
Xのマークアップ変更に追従し、サイドナビの設定を整理

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -54,17 +54,11 @@
   "titleIsGrokHidden": {
     "message": "Hide Grok"
   },
-  "titleIsJobsHidden": {
-    "message": "Hide Jobs"
-  },
-  "titleIsCommunitiesHidden": {
-    "message": "Hide Communities"
-  },
   "titleIsPremiumHidden": {
     "message": "Hide Premium"
   },
-  "titleIsVerifiedOrganizationsHidden": {
-    "message": "Hide Verified Organizations"
+  "titleIsCreatorStudioHidden": {
+    "message": "Hide Creator Studio"
   },
   "titleBasicSettings": {
     "message": "Basic settings"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -50,17 +50,11 @@
   "titleIsGrokHidden": {
     "message": "Grokを隠す"
   },
-  "titleIsJobsHidden": {
-    "message": "求人を隠す"
-  },
-  "titleIsCommunitiesHidden": {
-    "message": "コミュニティを隠す"
-  },
   "titleIsPremiumHidden": {
     "message": "プレミアムを隠す"
   },
-  "titleIsVerifiedOrganizationsHidden": {
-    "message": "認証済み組織を隠す"
+  "titleIsCreatorStudioHidden": {
+    "message": "クリエイタースタジオを隠す"
   },
   "titleBasicSettings": {
     "message": "基本設定"

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -56,20 +56,12 @@
         <span>__MSG_titleIsGrokHidden__</span>
       </label>
       <label class="check">
-        <input type="checkbox" id="isJobsHidden" checked>
-        <span>__MSG_titleIsJobsHidden__</span>
-      </label>
-      <label class="check">
-        <input type="checkbox" id="isCommunitiesHidden" checked>
-        <span>__MSG_titleIsCommunitiesHidden__</span>
-      </label>
-      <label class="check">
         <input type="checkbox" id="isPremiumHidden" checked>
         <span>__MSG_titleIsPremiumHidden__</span>
       </label>
       <label class="check">
-        <input type="checkbox" id="isVerifiedOrganizationsHidden" checked>
-        <span>__MSG_titleIsVerifiedOrganizationsHidden__</span>
+        <input type="checkbox" id="isCreatorStudioHidden" checked>
+        <span>__MSG_titleIsCreatorStudioHidden__</span>
       </label>
     </div>
   </section>

--- a/app/scripts/constants.ts
+++ b/app/scripts/constants.ts
@@ -12,10 +12,8 @@ export const DEFAULT_SETTINGS = {
   isTopicsToFollowHidden: false,
   isFontChanged: false,
   isGrokHidden: true,
-  isJobsHidden: true,
-  isCommunitiesHidden: true,
   isPremiumHidden: true,
-  isVerifiedOrganizationsHidden: true,
+  isCreatorStudioHidden: true,
 } as const;
 
 export const SECTION_STATES = {

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -204,42 +204,15 @@ body {
   }
 
   &.isFollowingNumberHidden {
-    div.r-u8s1d div.r-1upvrn0,
-    div.r-u8s1d div.r-xnswec,
-    div.r-u8s1d div.r-qo02w8 {
-      div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child {
-        display: none !important;
-      }
-    }
-
-    div[data-testid="primaryColumn"] > div > div > div > div > div {
-      & div.css-175oi2r.r-dr54s0 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child,
-      & div.css-175oi2r.r-1cad53l > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child,
-      & div.css-175oi2r.r-ku1wi2 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child,
-      & div.css-175oi2r.r-1ifxtd0 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child,
-      & div.css-175oi2r.r-le4sbl > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:first-child > a > span:first-child {
-        display: none !important;
-      }
+    a[href$="/following"] > span:first-child {
+      display: none !important;
     }
   }
 
   &.isFollowerNumberHidden {
-    div.r-u8s1d div.r-1upvrn0,
-    div.r-u8s1d div.r-xnswec,
-    div.r-u8s1d div.r-qo02w8 {
-      div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child {
-        display: none !important;
-      }
-    }
-
-    div[data-testid="primaryColumn"] > div > div > div > div > div {
-      & div.css-175oi2r.r-dr54s0 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child,
-      & div.css-175oi2r.r-1cad53l > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child,
-      & div.css-175oi2r.r-ku1wi2 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child,
-      & div.css-175oi2r.r-1ifxtd0 > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child,
-      & div.css-175oi2r.r-le4sbl > div.css-175oi2r.r-18u37iz.r-1w6e6rj > div:last-child > a > span:first-child {
-        display: none !important;
-      }
+    a[href$="/verified_followers"] > span:first-child,
+    a[href$="/followers"] > span:first-child {
+      display: none !important;
     }
   }
 

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -217,9 +217,10 @@ body {
   }
 
   &.isWhoToFollowHidden {
-    div[data-testid="primaryColumn"] > div > div > div > div > section > div > div > div > div  {
-      *[data-testid="UserCell"],
-      a[href*="/i/connect_people?user_id="] {
+    div[data-testid="primaryColumn"] {
+      section:has(a[href*="/i/connect_people"]) *[data-testid="UserCell"],
+      section:has(a[href*="/i/connect_people"]) div[data-testid="cellInnerDiv"]:has(h2),
+      a[href*="/i/connect_people"] {
         display: none;
       }
     }

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -22,24 +22,12 @@ body {
     }
   }
 
-  &.isJobsHidden {
-    header a[href*="/jobs"] {
+  &.isCreatorStudioHidden {
+    header a[href*="/i/jf/creators/studio"] {
       display: none !important;
     }
   }
-  
-  &.isCommunitiesHidden {
-    header a[href*="/communities"] {
-      display: none !important;
-    }
-  }
-  
-  &.isVerifiedOrganizationsHidden {
-    header a[href*="/i/verified-orgs-signup"] {
-      display: none !important;
-    }
-  }
-  
+
   &.isTrendsHidden {
     div[data-testid="sidebarColumn"] {
       div:has(> div > aside > a[href="/i/premium_sign_up"]),


### PR DESCRIPTION
## 概要

Xのマークアップ変更で動かなくなっていた非表示機能を修正し、サイドナビの設定を現状に合わせて整理する。

同じ修正を繰り返しているため、難読クラスやDOM階層に依存しない`href`ベースのセレクタに置き換えた。

## 主な変更内容

- フォロー数・フォロワー数が隠れないのを修正
- おすすめユーザーが隠れないのを修正。見出しもあわせて非表示にする
- サイドナビにクリエイタースタジオを追加
- 求人、コミュニティ、認証済み組織を削除。後者2つは「もっと見る」内に移動しており対象外のため

## 確認項目

- [x] Chrome拡張機能として正常にビルドできる
- [x] プロフィール画面とポップアップでフォロー数・フォロワー数が隠れる
- [x] フォロワー一覧画面のタブや一覧本体に影響がない
- [x] タイムラインとプロフィールでおすすめユーザーが見出しごと隠れる
- [x] 通常のツイートが巻き込まれない
- [x] クリエイタースタジオが隠れる
- [x] 「もっと見る」内のコミュニティとビジネスは隠れない

## 関連Issue

Closes #73
Closes #74
