### PR TITLE
右カラムの非表示要素をvisibility: hiddenに変更

### DIFF
--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -36,7 +36,7 @@ body {
       div:has(> div[data-testid="placementTracking"] > button div[data-testid="pill-contents-container"] div[data-testid="UserAvatar-Container-unknown"]),
       div[data-testid="super-upsell-UpsellCardRenderProperties"],
       div:has(> div[data-testid="news_sidebar"]) {
-        display: none !important;
+        visibility: hidden !important;
       }
     }
   }


### PR DESCRIPTION
## 概要
右カラムの非表示要素を `display: none` から `visibility: hidden` に変更した。

## 背景
`display: none` では隠した要素の分だけ後続要素が繰り上がるため、本来ファーストビューの外にあった広告が画面上部に表示され、周囲が空白の中で唯一のコンテンツとして目立つ状態になっていた。

広告を目立たなくしたい一方で、無料サービスの収益源に手を加えることは避けたい。`visibility: hidden` はレイアウト上の位置を保持するため、隠す対象は見えなくなりつつ、広告はXが描画する本来の位置に留まる。位置も表示も改変せずにおだやかさを実現できる。

## 動作確認
ファーストビューには何も表示されず、スクロールすると広告が本来の位置に表示されることを確認した。隠したセクションの分だけカラム上部に空白が残るが、これを詰めることは広告をファーストビューに繰り上げることと同義なため意図した挙動とする。

Closes #84
